### PR TITLE
Fix wrong int type in Windows

### DIFF
--- a/.github/workflows/build-wheels-upload-pypi.yml
+++ b/.github/workflows/build-wheels-upload-pypi.yml
@@ -18,7 +18,13 @@ jobs:
   # The first and second job run in parallel.
   # The uploading jos needs to have the other two finished without error.
 
+  # From now on, we run the tests before continuing with these jobs.
+
+  run_tests:
+    uses: ./.github/workflows/python-package-tox.yml
+
   build_sdist:
+    needs: [run_tests]
 
     # First the source distribution is done on ubuntu. This is not related
     # to any operating system, so we could do it on the default os.
@@ -60,6 +66,7 @@ jobs:
           path: dist/*.tar.gz
 
   build_wheels:
+    needs: [run_tests]
 
     # Second the wheels are build for different OS and python versions. This is
     # done with the help of the `cibuildwheel` package.

--- a/.github/workflows/python-package-tox.yml
+++ b/.github/workflows/python-package-tox.yml
@@ -1,21 +1,18 @@
 # This workflow will install tox and use it to run tests.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: run_tests
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, workflow_call, workflow_dispatch, pull_request]
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python: ["3.9", "3.10", "3.11", "3.12"]
+        os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/sep_pjw.pyx
+++ b/sep_pjw.pyx
@@ -443,7 +443,7 @@ cdef class Background:
         def __get__(self):
             return sep_bkg_globalrms(self.ptr)
 
-    def back(self, dtype=None):
+    def back(self, dtype=None, copy=None):
         """back(dtype=None)
 
         Create an array of the background.
@@ -473,7 +473,10 @@ cdef class Background:
         status = sep_bkg_array(self.ptr, &buf[0, 0], sep_dtype)
         _assert_ok(status)
 
-        return result
+        if copy:
+            return result.copy()
+        else:
+            return result
 
     def rms(self, dtype=None):
         """rms(dtype=None)
@@ -540,8 +543,8 @@ cdef class Background:
         status = sep_bkg_subarray(self.ptr, &buf[0, 0], sep_dtype)
         _assert_ok(status)
 
-    def __array__(self, dtype=None):
-        return self.back(dtype=dtype)
+    def __array__(self, dtype=None, copy=None):
+        return self.back(dtype=dtype, copy=copy)
 
     def __rsub__(self, np.ndarray data not None):
         data = np.copy(data)

--- a/sep_pjw.pyx
+++ b/sep_pjw.pyx
@@ -586,7 +586,7 @@ cdef packed struct Object:
     np.int64_t ycpeak
     np.int64_t xpeak
     np.int64_t ypeak
-    long flag
+    short flag
 
 default_kernel = np.array([[1.0, 2.0, 1.0],
                            [2.0, 4.0, 2.0],
@@ -807,7 +807,7 @@ def extract(np.ndarray data not None, float thresh, err=None, var=None,
                                       ('ycpeak', np.int64),
                                       ('xpeak', np.int64),
                                       ('ypeak', np.int64),
-                                      ('flag', np.int_)]))
+                                      ('flag', np.short)]))
 
     for i in range(catalog.nobj):
         result['thresh'][i] = catalog.thresh[i]

--- a/test.py
+++ b/test.py
@@ -413,9 +413,17 @@ def test_extract_with_noise_array():
     # convolved. Near edges, the convolution doesn't adjust for pixels
     # off edge boundaries. As a result, the convolved noise map is not
     # all ones.
-    objects = sep.extract(data, 1.5 * bkg.globalrms, filter_kernel=None)
+    # Deblending is also turned off, as this appears to differ slightly
+    # across platforms - see `test_vs_sextractor()`.
+    objects = sep.extract(
+        data, 1.5 * bkg.globalrms, filter_kernel=None, deblend_cont=1.0
+    )
     objects2 = sep.extract(
-        data, 1.5 * bkg.globalrms, err=np.ones_like(data), filter_kernel=None
+        data,
+        1.5 * bkg.globalrms,
+        err=np.ones_like(data),
+        filter_kernel=None,
+        deblend_cont=1.0,
     )
 
     names_to_remove = ["errx2", "erry2", "errxy"]
@@ -423,18 +431,18 @@ def test_extract_with_noise_array():
     objects = objects[names_to_keep]
     objects2 = objects2[names_to_keep]
 
-    assert_equal(objects, objects2)
+    assert_allclose_structured(objects, objects2)
 
     # Less trivial test where thresh is realistic. Still a flat noise map.
     noise = bkg.globalrms * np.ones_like(data)
-    objects2 = sep.extract(data, 1.5, err=noise, filter_kernel=None)
+    objects2 = sep.extract(data, 1.5, err=noise, filter_kernel=None, deblend_cont=1.0)
 
     names_to_remove = ["errx2", "erry2", "errxy"]
     names_to_keep = [i for i in objects.dtype.names if i not in names_to_remove]
     objects = objects[names_to_keep]
     objects2 = objects2[names_to_keep]
 
-    assert_equal(objects, objects2)
+    assert_allclose_structured(objects, objects2)
 
 
 def test_extract_with_noise_convolution():


### PR DESCRIPTION
Correct the return type for `flag` in `sep.extract()` when run on Windows machines. Updates to tests and workflows to hopefully avoid future bugs of this type.