### PR TITLE
Python 3.13 Support

### DIFF
--- a/.github/workflows/build-wheels-upload-pypi.yml
+++ b/.github/workflows/build-wheels-upload-pypi.yml
@@ -72,7 +72,7 @@ jobs:
     # done with the help of the `cibuildwheel` package.
     #
     # The wheels are built for Windows, Linux and MacOS and the python versions
-    # 3.9 - 3.12.
+    # 3.9 - 3.13.
     #
     # The three operating system could be done in parallel.
     name: Build wheels on ${{ matrix.os }}
@@ -116,7 +116,7 @@ jobs:
         if: matrix.cibw_archs == 'aarch64'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BUILD_VERBOSITY: 1
@@ -127,7 +127,7 @@ jobs:
         if: matrix.cibw_archs != 'aarch64'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/python-package-tox.yml
+++ b/.github/workflows/python-package-tox.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Install Tox and any other packages
         run: python -m pip install tox
       - name: Run Tox
-        # Run tox using the version of Python in `PATH`
-        run: tox -e py
+        # Run tox using the version of Python in `PATH`, append platform
+        run: tox -e py-$(python -c "import sys; print(sys.platform)")

--- a/.github/workflows/python-package-tox.yml
+++ b/.github/workflows/python-package-tox.yml
@@ -21,7 +21,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox and any other packages
-        run: python -m pip install tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox tox-gh-actions
       - name: Run Tox
         # Run tox using the version of Python in `PATH`, append platform
-        run: tox -e py-$(python -c "import sys; print(sys.platform)")
+        run: tox
+        env:
+          PLATFORM: ${{ matrix.os }}

--- a/.github/workflows/python-package-tox.yml
+++ b/.github/workflows/python-package-tox.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
     # You can also specify other tool versions:
     # nodejs: "20"
     # rust: "1.70"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+v1.3.7 (8 November 2024)
+========================
+
+* Test against Python 3.13.
+* Update the Makefile to support Semantic Versioning from git tags.
+* Update the C libraries to allow for passing the version as a compiler
+  flag.
+* Update `setup.py` to pass the SCM version to the Cython compiler.
+* Include C tests in the Tox suite (for linux and macos only).
+* Document any and all changes to the C API since forking.
+* Restructure changelog documentation.
+
 v1.3.6 (7 October 2024)
 =======================
 
@@ -65,178 +77,3 @@ v1.3.0 (1 December 2023)
   ([#122](https://github.com/kbarbary/sep/issues/122 "Original issue"),
   inspired by [Gabe Brammer's fork](https://github.com/gbrammer/sep)
   with additional fixes).
-
-
-v1.2.1 (1 June 2022)
-====================
-
-* Same as v1.2.0 but with new wheels for Python 3.10 and AArch64.
-
-v1.2.0 (1 May 2021)
-===================
-
-* Changed `numpy.float` and `numpy.int` types for deprecations in numpy 1.20 (#96).
-
-* Make it possible to safely invoke C library from multiple threads on
-  independent inputs.
-
-  Global config functions such as `set_sub_object_limit()`
-  and `set_extract_pixstack()` still configure global params
-  (once for all threads), while other functions will retain their data
-  in thread-local storages, so they can be invoked from multiple threads as
-  long as they work on independent structures.
-
-  Library compilation will now require a C11 compatible compiler, which should
-  be nowadays available on all supported platforms.
-
-* Mark some pointer parameters with `const *`. This is a backward-compatible
-  change, but makes it easier to extract constants that can be safely shared
-  between multiple threads and/or invocations.
-
-v1.1.1 (6 January 2021)
-=======================
-
-* Same as v1.1.0 but with wheels built and uploaded to PyPI. Please report if you
-  have problems with wheels.
-
-
-v1.1.0 (3 January 2021)
-=======================
-
-* Add segmentation masking to the photometry and kron/auto functions (#69).
-
-* Add functions `sep.set_sub_object_limit(limit)` and `sep.get_sub_object_limit()`
-  for modifying and retrieving the sub-object deblending limit. Previously this
-  parameter was hard-coded to 1024. 1024 is now the default value.
-
-* This and future versions are now Python 3 only. Python 2 is no longer
-  supported.
-
-* Modernize setup.py with pyproject.toml
-
-
-v1.0.3 (12 June 2018)
-=====================
-
-* Fix double-free bug in sep_extract() arising when an error status occurs
-  and convolution is on. (#56)
-
-* Work around numpy dependency in setup. (#59)
-
-
-v1.0.2 (19 September 2017)
-==========================
-
-* Fix makefile so that `make install` works on OS X for the C library.
-  Python module and C code are unchanged.
-
-
-v1.0.1 (10 July 2017)
-=====================
-
-* Fix bug when using masked filter and noise array where objects with member
-  pixels at end of image (maximum y coordinate) were erroneously missed.
-
-
-v1.0.0 (30 September 2016)
-==========================
-
-* Remove features deprecated in previous versions.
-
-* Fix bug in Background.rms() giving nonsensical results.
-
-v0.6.0 (25 August 2016)
-=======================
-
-* New, more coherent C API. This change should be transparent to users
-  of the Python module.
-
-* Add variance uncertainty parameters `errx2`, `erry2` and `errxy` to
-  output of `sep.extract()`.
-
-* Add a minimum sigma to `sep.winpos()` to match Source Extractor
-  behavior.
-
-* Fix use of boolean masks in `sep.kron_radius()`. Formerly, using a
-  boolean mask resulted in nonsense results.
-
-* Fix segfault in `Background.back()` when box size is same as image size.
-
-* Fix bug in creating long error messages on Python 3.
-
-v0.5.2 (4 January 2016)
-=======================
-
-Adds OS X and Windows support.
-
-v0.5.1 (30 November 2015)
-=========================
-
-Bugfix release for problem in setup.py in packaged code.
-
-v0.5.0 (22 November 2015)
-=========================
-
-* `sep.extract()` now uses a more correct matched filter algorithm in the
-  presence of a noise array, rather than simple convolution. The `conv`
-  keyword has been changed to `filter_kernel` to reflect this, and a
-  `filter_type` keyword has been added to allow selecting the old behavior
-  of simple convolution.
-
-* `sep.extract()` now accepts a `mask` keyword argument.
-
-* `sep.extract()` can now return a segmentation map.
-
-* Special methods added to allow `data - bkg` and `np.array(bkg)` where
-  `bkg` is a Background object.
-
-v0.4.1 (10 November 2015)
-=========================
-
-Bugfix release, fixing error estimate in `sep.sum_circle` and
-`sep.sum_ellipse` when `bkgann` keyword argument is given.
-
-v0.4.0 (1 June 2015)
-====================
-
-* New `sep.winpos()` function.
-
-v0.3.0 (23 February 2015)
-=========================
-
-* New `sep.flux_radius()` function.
-
-v0.2.0 (13 December 2014)
-=========================
-
-* **[breaking change]** `theta` field in `extract()` output is now in
-  radians rather than degrees, for compatibility with new ellipse
-  aperture functions.
-
-* **[deprecation]** Change `mask_ellipse()` parameters from ellipse
-  coefficients to ellipse axes and position angle, to match aperture
-  functions. (Old behavior still works as well.)
-
-* **[deprecation]** Change `apercirc()` to `sum_circle()`, to match
-  new aperture functions. (Old name, `apercirc()`, still works.)
-
-* Add `sum_circann()`, `sum_ellipse()`, `sum_ellipann()`,
-  `kron_radius()`, `ellipse_coeffs()`, `ellipse_axes()` functions.
-
-* Exact mode aperture photometery in all functions, with `subpix=0`.
-
-* Enable variable thresholding in `sep.extract`. [#11]
-
-* Fix bug in background masking. This bug impacted masking in all
-  functions that used masking. Also affected C library.
-
-* More detail in error messages coming from within the C library.
-  More helpful error message for non-native byteorder arrays.
-
-* Add ability to change pixel stack size used in `extract()`, with
-  `set_extract_pixstack()` function
-
-v0.1.0 (11 August 2014)
-=======================
-
-This is the first official release.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@ SEP-PJW
 
 Python and C library for Source Extraction and Photometry, forked from [kbarbary/sep](https://github.com/kbarbary/sep) to provide additional features and bug fixes.
 
+[![PyPI](https://img.shields.io/pypi/v/sep-pjw?label=PyPI)](https://pypi.python.org/pypi/sep-pjw)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/sep-pjw?label=PyPI%20Downloads)
+](https://pypi.python.org/pypi/sep-pjw)
 ![Build Status](https://github.com/PJ-Watson/sep-pjw/workflows/CI/badge.svg)
-[![PyPI](https://img.shields.io/pypi/v/sep-pjw.svg)](https://pypi.python.org/pypi/sep-pjw)
 [![Documentation Status](https://readthedocs.org/projects/sep-pjw/badge/?version=latest)](https://sep-pjw.readthedocs.io/en/latest/?badge=latest)
 [![JOSS](http://joss.theoj.org/papers/10.21105/joss.00058/status.svg)](http://dx.doi.org/10.21105/joss.00058)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,0 @@
-.. _changelog:
-
-Changelog
-=========
-
-.. include:: ../CHANGES.md
-   :parser: myst_parser.sphinx_

--- a/docs/changelogs/changelog.rst
+++ b/docs/changelogs/changelog.rst
@@ -1,0 +1,22 @@
+.. _changelog:
+
+Changelog
+=========
+
+
+Upgrading From kbarbary/sep
+---------------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   changes_to_c_api
+
+Full Changelog
+--------------
+
+.. toctree::
+   :maxdepth: 2
+
+   new_changes
+   original_changes

--- a/docs/changelogs/changes_to_c_api.rst
+++ b/docs/changelogs/changes_to_c_api.rst
@@ -1,0 +1,78 @@
+Changes to the C API
+====================
+
+This page details cumulative changes to the C API between v1.2.1 and
+v1.3.7, or since this package was forked from
+`kbarbary/sep <https://github.com/kbarbary/sep>`_. Almost all changes to
+the public API are to integer parameters, many of which have been changed
+from ``int`` to ``int64_t``, to fix problems which may arise with
+extremely large arrays. The other change of note is to the ``sep_image``
+struct, which enables the user to pass an existing segmentation map, and
+re-extract all morphological and photometric quantities on a different
+image.
+
+All changes here are transparent to users of the Python interface.
+
+.. c:struct::  sep_image
+
+ - Three new parameters have been added:
+
+   .. c:var:: int64_t * segids
+
+      The unique ids in an existing segmentation map.
+
+   .. c:var:: int64_t * idcounts
+
+      The number of occurrences of each unique id in an existing segmentation map.
+
+   .. c:var:: int64_t numids
+
+      The total number of unique ids in an existing segmentation map.
+
+ - The type of ``w``` and ``h``` has changed from ``int`` to ``int64_t``.
+
+.. c:struct:: sep_bkg
+
+ - The type of the following parameters has changed from ``int`` to ``int64_t``: ``w``, ``h``, ``bw``, ``bh``, ``nx``, ``ny``, and ``n``.
+
+.. c:struct:: sep_catalog
+
+ - The type of the following parameters has changed from ``int`` to ``int64_t``: ``npix``, ``tnpix``, ``xmin``, ``xmax``, ``ymin``, ``ymax``, ``xcpeak``, ``ycpeak``, ``xpeak``, ``ypeak``, ``pix``, and ``objectspix``.
+
+.. c:function:: int sep_background()
+
+ - The type of the following parameters has changed from ``int`` to
+   ``int64_t``: ``bw``, ``bh``, ``fw``, and ``fh``.
+
+.. c:function:: float sep_bkg_pix()
+
+ - The type of ``x`` and ``y`` has changed from ``int`` to ``int64_t``.
+
+.. c:function:: int sep_bkg_line()
+
+ - The type of ``y`` has changed from ``int`` to ``int64_t``.
+
+.. c:function:: int sep_bkg_subline()
+
+ - The type of ``y`` has changed from ``int`` to ``int64_t``.
+
+.. c:function:: int sep_bkg_rmsline()
+
+ - The type of ``y`` has changed from ``int`` to ``int64_t``.
+
+.. c:function:: int sep_extract()
+
+ - The type of ``convw`` and ``convh`` has changed from ``int`` to
+   ``int64_t``.
+
+.. c:function:: int sep_sum_circann_multi()
+
+ - The type of ``n`` has changed from ``int`` to ``int64_t``.
+
+.. c:function:: int sep_flux_radius()
+
+ - The type of ``n`` has changed from ``int`` to ``int64_t``.
+
+.. c:function:: void sep_set_ellipse()
+
+ - The type of ``w`` and ``h`` has changed from ``int`` to ``int64_t``.

--- a/docs/changelogs/new_changes.rst
+++ b/docs/changelogs/new_changes.rst
@@ -1,0 +1,7 @@
+New Changelog
+=============
+
+**Full Changelog**
+
+.. include:: ../../CHANGES.md
+   :parser: myst_parser.sphinx_

--- a/docs/changelogs/original_changes.md
+++ b/docs/changelogs/original_changes.md
@@ -1,0 +1,179 @@
+Original Changelog
+==================
+
+This is the original changelog from [kbarbary/sep](https://github.com/kbarbary/sep),
+copied here for posterity.
+
+v1.2.1 (1 June 2022)
+--------------------
+
+* Same as v1.2.0 but with new wheels for Python 3.10 and AArch64.
+
+v1.2.0 (1 May 2021)
+-------------------
+
+* Changed `numpy.float` and `numpy.int` types for deprecations in numpy 1.20 (#96).
+
+* Make it possible to safely invoke C library from multiple threads on
+  independent inputs.
+
+  Global config functions such as `set_sub_object_limit()`
+  and `set_extract_pixstack()` still configure global params
+  (once for all threads), while other functions will retain their data
+  in thread-local storages, so they can be invoked from multiple threads as
+  long as they work on independent structures.
+
+  Library compilation will now require a C11 compatible compiler, which should
+  be nowadays available on all supported platforms.
+
+* Mark some pointer parameters with `const *`. This is a backward-compatible
+  change, but makes it easier to extract constants that can be safely shared
+  between multiple threads and/or invocations.
+
+v1.1.1 (6 January 2021)
+-----------------------
+
+* Same as v1.1.0 but with wheels built and uploaded to PyPI. Please report if you
+  have problems with wheels.
+
+
+v1.1.0 (3 January 2021)
+-----------------------
+
+* Add segmentation masking to the photometry and kron/auto functions (#69).
+
+* Add functions `sep.set_sub_object_limit(limit)` and `sep.get_sub_object_limit()`
+  for modifying and retrieving the sub-object deblending limit. Previously this
+  parameter was hard-coded to 1024. 1024 is now the default value.
+
+* This and future versions are now Python 3 only. Python 2 is no longer
+  supported.
+
+* Modernize setup.py with pyproject.toml
+
+
+v1.0.3 (12 June 2018)
+---------------------
+
+* Fix double-free bug in sep_extract() arising when an error status occurs
+  and convolution is on. (#56)
+
+* Work around numpy dependency in setup. (#59)
+
+
+v1.0.2 (19 September 2017)
+--------------------------
+
+* Fix makefile so that `make install` works on OS X for the C library.
+  Python module and C code are unchanged.
+
+
+v1.0.1 (10 July 2017)
+---------------------
+
+* Fix bug when using masked filter and noise array where objects with member
+  pixels at end of image (maximum y coordinate) were erroneously missed.
+
+
+v1.0.0 (30 September 2016)
+--------------------------
+
+* Remove features deprecated in previous versions.
+
+* Fix bug in Background.rms() giving nonsensical results.
+
+v0.6.0 (25 August 2016)
+-----------------------
+
+* New, more coherent C API. This change should be transparent to users
+  of the Python module.
+
+* Add variance uncertainty parameters `errx2`, `erry2` and `errxy` to
+  output of `sep.extract()`.
+
+* Add a minimum sigma to `sep.winpos()` to match Source Extractor
+  behavior.
+
+* Fix use of boolean masks in `sep.kron_radius()`. Formerly, using a
+  boolean mask resulted in nonsense results.
+
+* Fix segfault in `Background.back()` when box size is same as image size.
+
+* Fix bug in creating long error messages on Python 3.
+
+v0.5.2 (4 January 2016)
+-----------------------
+
+Adds OS X and Windows support.
+
+v0.5.1 (30 November 2015)
+-------------------------
+
+Bugfix release for problem in setup.py in packaged code.
+
+v0.5.0 (22 November 2015)
+-------------------------
+
+* `sep.extract()` now uses a more correct matched filter algorithm in the
+  presence of a noise array, rather than simple convolution. The `conv`
+  keyword has been changed to `filter_kernel` to reflect this, and a
+  `filter_type` keyword has been added to allow selecting the old behavior
+  of simple convolution.
+
+* `sep.extract()` now accepts a `mask` keyword argument.
+
+* `sep.extract()` can now return a segmentation map.
+
+* Special methods added to allow `data - bkg` and `np.array(bkg)` where
+  `bkg` is a Background object.
+
+v0.4.1 (10 November 2015)
+-------------------------
+
+Bugfix release, fixing error estimate in `sep.sum_circle` and
+`sep.sum_ellipse` when `bkgann` keyword argument is given.
+
+v0.4.0 (1 June 2015)
+--------------------
+
+* New `sep.winpos()` function.
+
+v0.3.0 (23 February 2015)
+-------------------------
+
+* New `sep.flux_radius()` function.
+
+v0.2.0 (13 December 2014)
+-------------------------
+
+* **[breaking change]** `theta` field in `extract()` output is now in
+  radians rather than degrees, for compatibility with new ellipse
+  aperture functions.
+
+* **[deprecation]** Change `mask_ellipse()` parameters from ellipse
+  coefficients to ellipse axes and position angle, to match aperture
+  functions. (Old behavior still works as well.)
+
+* **[deprecation]** Change `apercirc()` to `sum_circle()`, to match
+  new aperture functions. (Old name, `apercirc()`, still works.)
+
+* Add `sum_circann()`, `sum_ellipse()`, `sum_ellipann()`,
+  `kron_radius()`, `ellipse_coeffs()`, `ellipse_axes()` functions.
+
+* Exact mode aperture photometery in all functions, with `subpix=0`.
+
+* Enable variable thresholding in `sep.extract`. [#11]
+
+* Fix bug in background masking. This bug impacted masking in all
+  functions that used masking. Also affected C library.
+
+* More detail in error messages coming from within the C library.
+  More helpful error message for non-native byteorder arrays.
+
+* Add ability to change pixel stack size used in `extract()`, with
+  `set_extract_pixstack()` function
+
+v0.1.0 (11 August 2014)
+-----------------------
+
+This is the first official release.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,7 +100,7 @@ Usage Guide
    tutorial
    filter
    apertures
-   changelog
+   changelogs/changelog
 
 .. toctree::
    :hidden:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ version_file = "src/_version.py"
 
 [tool.black]
 line-length = 88
-target-version = ['py311']
+target-version = ['py312']
 extend-exclude = '(.*.txt|.*.md|.*.toml|.*.odg)'
 preview = true
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,11 @@ def _new_local_scheme(version: ScmVersion) -> str:
     return version.format_choice("", "-{node}")
 
 
+c_version_string = get_version(
+    version_scheme=_new_version_scheme,
+    local_scheme=_new_local_scheme,
+)
+
 # from setuptools import setup
 from setuptools.dist import Distribution
 
@@ -54,12 +59,7 @@ else:
                 ("_USE_MATH_DEFINES", "1"),
                 ("NPY_NO_DEPRECATED_API", "NPY_2_0_API_VERSION"),
             ],
-            extra_compile_args=[f"""-DSEP_VERSION_STRING='{
-                    get_version(
-                        version_scheme=_new_version_scheme,
-                        local_scheme=_new_local_scheme,
-                    )
-                }'"""],
+            extra_compile_args=['-DSEP_VERSION_STRING="' + c_version_string + '"'],
         )
     ]
     extensions = cythonize(

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,19 @@ import sys
 from glob import glob
 
 from setuptools import Extension, setup
+from setuptools_scm import ScmVersion, get_version
+from setuptools_scm.version import guess_next_version
+
+
+def _new_version_scheme(version: ScmVersion) -> str:
+
+    return version.format_next_version(guess_next_version, "{guessed}-dev{distance}")
+
+
+def _new_local_scheme(version: ScmVersion) -> str:
+
+    return version.format_choice("", "-{node}")
+
 
 # from setuptools import setup
 from setuptools.dist import Distribution
@@ -41,6 +54,12 @@ else:
                 ("_USE_MATH_DEFINES", "1"),
                 ("NPY_NO_DEPRECATED_API", "NPY_2_0_API_VERSION"),
             ],
+            extra_compile_args=[f"""-DSEP_VERSION_STRING='{
+                    get_version(
+                        version_scheme=_new_version_scheme,
+                        local_scheme=_new_local_scheme,
+                    )
+                }'"""],
         )
     ]
     extensions = cythonize(

--- a/src/util.c
+++ b/src/util.c
@@ -25,7 +25,10 @@
 
 #define DETAILSIZE 512
 
-const char * const sep_version_string = "1.3.5";
+#ifndef SEP_VERSION_STRING
+#define SEP_VERSION_STRING "1.3.6"
+#endif
+const char * const sep_version_string = SEP_VERSION_STRING;
 static _Thread_local char _errdetail_buffer[DETAILSIZE] = "";
 
 /****************************************************************************/

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,14 @@
 [tox]
-minversion = 3.3
-envlist = py3
+minversion = 4.0
+envlist = py3-linux
 isolated_build = true
 
 [testenv]
 passenv = HOME
 deps = pytest
        astropy
-commands = pytest test.py
+allowlist_externals = make
+commands =
+       linux: make test
+       darwin: make test
+       pytest test.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,13 @@
 [tox]
 minversion = 4.0
-envlist = py3-linux
+envlist = py-{linux,macos,windows}
 isolated_build = true
+
+[gh-actions:env]
+PLATFORM =
+    ubuntu-latest: linux
+    macos-latest: macos
+    windows-latest: windows
 
 [testenv]
 passenv = HOME
@@ -9,6 +15,6 @@ deps = pytest
        astropy
 allowlist_externals = make
 commands =
-       linux: make test
-       darwin: make test
        pytest test.py
+       linux: make test
+       macos: make test


### PR DESCRIPTION
Add support for Python 3.13. Also check any changes in the C-API since forking, and properly document those.